### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,6 @@
 /.gitignore             export-ignore
 /.github                export-ignore
 /.editorconfig          export-ignore
-/phpunit.xml       		export-ignore
+/phpunit.xml            export-ignore
 /phpstan.neon.dist      export-ignore
 /tests                  export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore paths when git creates an archive of this package
+/.gitattributes         export-ignore
+/.gitignore             export-ignore
+/.github                export-ignore
+/.editorconfig          export-ignore
+/phpunit.xml       		export-ignore
+/phpstan.neon.dist      export-ignore
+/tests                  export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 composer.lock
 files/
 repo/
-vendor/
 tests/_support/_generated
 bin/*.phar
 tests/var


### PR DESCRIPTION
This will make the package smaller in the vendor folder when required by other projects.

Also, removes a duplicate `vendor/` item in .gitignore. 